### PR TITLE
1 type annotation is missing for parameter snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ To update this snapshot, run: pytest --snap-update
 FAILED tests/unit_test.py::test_very_long - Failed: Snapshot mismatch for unit_test__test_very_long_0.txt
 ```
 
+## Type hints
+You can use a type hint for the `snap` fixture if you want to:
+
+```python
+from pytest_snap import SnapshotFixture
+
+def test_api_response(snap : SnapshotFixture):
+    assert snap(".json", json.dumps({"message": "Hello"}))
+```
+
+
 ## Optional feature: Rounding floating point numbers
 The `snap` fixture has an optional argument `digits` which allows you to round all floats within your snapshot string to `digits` significant digits.
 

--- a/src/pytest_snap/__init__.py
+++ b/src/pytest_snap/__init__.py
@@ -1,2 +1,3 @@
-def hello() -> str:
-    return "Hello from pytest-snap!"
+from .plugin import SnapshotFixture, snap
+
+__all__ = ["SnapshotFixture", "snap"]

--- a/src/pytest_snap/plugin.py
+++ b/src/pytest_snap/plugin.py
@@ -65,13 +65,18 @@ class SnapSession:
         pytest.fail(error_msg, pytrace=False)
 
 
-# Global session instance
-_session = SnapSession()
+class SnapshotFixture:
+    """Snapshot fixture.
 
+    Usage: def test_xxx(snap: SnapshotFixture)
+    """
 
-def snap_impl(extension: str, content: str, digits: int | None = None) -> bool:
-    """Implementation of the snap function injected into test modules."""
-    return _session.compare_or_create_snapshot(extension, content, digits)
+    def __init__(self, session: SnapSession):
+        self._session = session
+
+    def __call__(self, extension: str, content: str, digits: int | None = None) -> bool:
+        """Create or compare a snapshot."""
+        return self._session.compare_or_create_snapshot(extension, content, digits)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -100,14 +105,18 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     _session.snapshot_counters[test_key] = 0
 
 
+# Global session instance
+_session = SnapSession()
+
+
 @pytest.fixture
-def snap(request):
+def snap() -> SnapshotFixture:
     """
     Pytest fixture for snapshot testing.
 
-    Allows tests to use `def test_xxx(snap):` and call snap(".ext", content).
+    Allows tests to use `def test_xxx(snap: SnapshotFixture)` and call snap(".ext", content).
     """
-    return snap_impl
+    return SnapshotFixture(_session)
 
 
 def _first_diff(expected: str, current: str) -> str:


### PR DESCRIPTION
- Allow users of library to type-hint the snap fixture
- Get rid of global session instance
- Mention type hint option in README
